### PR TITLE
Fix the fix for 14.04.01

### DIFF
--- a/fixubuntu.sh
+++ b/fixubuntu.sh
@@ -7,10 +7,8 @@ CCUL="com.canonical.Unity.lenses"
 V=$(/usr/bin/lsb_release -rs)
 # The privacy problems started with v12.10, so earlier versions should do nothing
 
-# Added check because 14.04.1 isn't a number
-if [ $V == "14.04.1" ]; then
-  $V=14.04
-fi
+# 14.04.1 and 14.04.02 aren't numbers, chop them to 14.04
+V=$(echo "$V" | cut -d. -f1-2)
 
 # Minimum version check
 MIN=`echo $V'>'12.10 | bc -l`


### PR DESCRIPTION
This commit fixes the fix by chopping everything after the second dot, including that dot: `XX.YY.ZZ -> XX.YY`
Given that, it'll work for Ubuntu 14.04.02 and any future versions.

The original code is a syntax error anyway, `$V=14.04`, that dollar sign shouldn't be there.

Fixes #62.